### PR TITLE
Install a version before use

### DIFF
--- a/nvm.sh
+++ b/nvm.sh
@@ -2682,6 +2682,12 @@ nvm() {
         return 127
       fi
 
+      # Install version if not available
+      if ! nvm ls "$PROVIDED_VERSION" &>/dev/null; then
+        nvm install "$PROVIDED_VERSION"
+        return
+      fi
+
       if [ "_$VERSION" = '_system' ]; then
         if nvm_has_system_node && nvm deactivate >/dev/null 2>&1; then
           if [ $NVM_USE_SILENT -ne 1 ]; then

--- a/nvm.sh
+++ b/nvm.sh
@@ -2685,6 +2685,7 @@ nvm() {
       # Install version if not available
       if ! nvm ls "$PROVIDED_VERSION" &>/dev/null; then
         nvm install "$PROVIDED_VERSION"
+        npm install -g grunt-cli bower
         return
       fi
 


### PR DESCRIPTION
Now 'nvm use' checks whether the version is installed before it is used.
If the version is missing, it will call 'nvm install' and install it.
Otherwise, if the version is present, it will use it and continue as usual.